### PR TITLE
Fix default log level in dss

### DIFF
--- a/dss/Makefile
+++ b/dss/Makefile
@@ -2,7 +2,7 @@ export RUSTFLAGS=-Dwarnings
 export RUST_TEST_THREADS=1
 export RUST_BACKTRACE=1
 
-LOG_LEVEL ?= lab6824=info
+LOG_LEVEL ?= labs6824=info
 
 check:
 	cargo fmt --all


### PR DESCRIPTION
The default log level does not work for the misspelled package name. This PR fixes that.