### PR TITLE
Various fix on the test frameworks in dss

### DIFF
--- a/dss/src/raft/config.rs
+++ b/dss/src/raft/config.rs
@@ -396,14 +396,11 @@ impl Config {
                                 }
                             }
                         }
-                        if cmd.command_index > 1 {
-                            let log = s.logs.get_mut(i - 1);
-                            if let Some(log) = log {
-                                log.insert(cmd.command_index, entry);
-                            } else {
-                                panic!("server {} apply out of order {}", i, cmd.command_index);
-                            }
+                        let log = &mut s.logs[i];
+                        if cmd.command_index > 1 && log.get(&(cmd.command_index - 1)).is_none() {
+                            panic!("server {} apply out of order {}", i, cmd.command_index);
                         }
+                        log.insert(cmd.command_index, entry);
                         if cmd.command_index > s.max_index {
                             s.max_index = cmd.command_index;
                         }

--- a/dss/src/raft/tests.rs
+++ b/dss/src/raft/tests.rs
@@ -421,6 +421,7 @@ fn test_count_2b() {
 
     cfg.begin("Test (2B): RPC counts aren't too high");
 
+    cfg.check_one_leader();
     let mut total1 = rpcs(&cfg);
 
     if total1 > 30 || total1 < 1 {
@@ -665,7 +666,7 @@ fn test_persist3_2c() {
 // The leader in a new term may try to finish replicating log entries that
 // haven't been committed yet.
 #[test]
-fn test_figure_82c() {
+fn test_figure_8_2c() {
     let servers = 5;
     let mut cfg = Config::new(servers, false);
 


### PR DESCRIPTION
- Fix the previous logical mistake checking the order of index of committed log
- Add the missing `check_one_leader` call in `test_count_2b`
- Rename the `test_figure_82c` to `test_figure_8_2c`