### PR TITLE
use GOMOD && go test -v && adjust bench_test

### DIFF
--- a/tidb/mergesort/Makefile
+++ b/tidb/mergesort/Makefile
@@ -1,10 +1,12 @@
+GO        := GO111MODULE=on go
+
 .PHONY: all
 
 all: test bench
 
 test:
-	go test
+	$(GO) test -v
 
 bench:
-	go test -bench Benchmark -run xx -count 5 -benchmem
+	$(GO) test -bench Benchmark -run xx -count 5 -check.b
 

--- a/tidb/mergesort/Makefile
+++ b/tidb/mergesort/Makefile
@@ -8,5 +8,5 @@ test:
 	$(GO) test -v
 
 bench:
-	$(GO) test -bench Benchmark -run xx -count 5 -check.b
+	$(GO) test -bench Benchmark -count 2 -v -check.b
 

--- a/tidb/mergesort/bench_test.go
+++ b/tidb/mergesort/bench_test.go
@@ -3,34 +3,45 @@ package main
 import (
 	"sort"
 	"testing"
+
+	"github.com/pingcap/check"
 )
 
-func BenchmarkMergeSort(b *testing.B) {
-	numElements := 16 << 20
-	src := make([]int64, numElements)
-	original := make([]int64, numElements)
-	prepare(original)
+var _ = check.Suite(&benchTestSuite{})
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		b.StopTimer()
+func TestBench(t *testing.T) {
+	check.TestingT(t)
+}
+
+type benchTestSuite struct{}
+
+const numElements = 16 << 20
+
+var (
+	src      []int64
+	original []int64
+)
+
+func (b *benchTestSuite) SetUpSuite(c *check.C) {
+	src = make([]int64, numElements)
+	original = make([]int64, numElements)
+	prepare(original)
+}
+
+func (b *benchTestSuite) BenchmarkMergeSort(c *check.C) {
+	for i := 0; i < c.N; i++ {
+		c.StopTimer()
 		copy(src, original)
-		b.StartTimer()
+		c.StartTimer()
 		MergeSort(src)
 	}
 }
 
-func BenchmarkNormalSort(b *testing.B) {
-	numElements := 16 << 20
-	src := make([]int64, numElements)
-	original := make([]int64, numElements)
-	prepare(original)
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		b.StopTimer()
+func (b *benchTestSuite) BenchmarkNormalSort(c *check.C) {
+	for i := 0; i < c.N; i++ {
+		c.StopTimer()
 		copy(src, original)
-		b.StartTimer()
+		c.StartTimer()
 		sort.Slice(src, func(i, j int) bool { return src[i] < src[j] })
 	}
 }


### PR DESCRIPTION
close #61 

  golang has not supported about `setup suite`, therefore, we should use `github.con/pingcap/check` to do this.

## **Side Effect:**
- Unfortunately, we could not run benchmem with this library.
```
xiekeyi@ubuntu:~/gopath/src/github.com/pingcap/talent-plan/tidb/mergesort$ GO111MODULE=on go test -bench=. -benchmem -check.b
PASS: bench_test.go:31: benchTestSuite.BenchmarkMergeSort	       1	6050466642 ns/op
PASS: bench_test.go:40: benchTestSuite.BenchmarkNormalSort	       1	6520338796 ns/op
OK: 2 passed
PASS: bench_test.go:31: benchTestSuite.BenchmarkMergeSort	       1	6810766632 ns/op
PASS: bench_test.go:40: benchTestSuite.BenchmarkNormalSort	       1	6462062544 ns/op
OK: 2 passed
PASS
```
Avoid misleading, I delete the `benchmem` flag.

- we have to run test with `-check.b` to benchmark.


## Manual test
```
xiekeyi@ubuntu:~/gopath/src/github.com/pingcap/talent-plan/tidb/mergesort$ git status
位于分支 master
您的分支与上游分支 'origin/master' 一致。

尚未暂存以备提交的变更：
  （使用 "git add <文件>..." 更新要提交的内容）
  （使用 "git checkout -- <文件>..." 丢弃工作区的改动）

	修改：     mergesort.go

修改尚未加入提交（使用 "git add" 和/或 "git commit -a"）

xiekeyi@ubuntu:~/gopath/src/github.com/pingcap/talent-plan/tidb/mergesort$ git diff
diff --git a/tidb/mergesort/mergesort.go b/tidb/mergesort/mergesort.go
index d518ecd..a7b0b65 100644
--- a/tidb/mergesort/mergesort.go
+++ b/tidb/mergesort/mergesort.go
@@ -1,6 +1,9 @@
 package main
 
+import "sort"
+
 // MergeSort performs the merge sort algorithm.
 // Please supplement this function to accomplish the home work.
 func MergeSort(src []int64) {
+       sort.Slice(src, func(i, j int) bool { return src[i] < src[j] })
 }

xiekeyi@ubuntu:~/gopath/src/github.com/pingcap/talent-plan/tidb/mergesort$ make test
GO111MODULE=on go test -v
=== RUN   TestBench
OK: 1 passed
--- PASS: TestBench (2.10s)
=== RUN   TestT
OK: 1 passed
--- PASS: TestT (2.10s)
PASS
ok  	pingcap/talentplan/tidb/mergesort	4.204s

xiekeyi@ubuntu:~/gopath/src/github.com/pingcap/talent-plan/tidb/mergesort$ make bench
GO111MODULE=on go test -bench Benchmark -count 2 -v -check.b
=== RUN   TestBench
PASS: bench_test.go:31: benchTestSuite.BenchmarkMergeSort	       1	6288027515 ns/op
PASS: bench_test.go:40: benchTestSuite.BenchmarkNormalSort	       1	6444257854 ns/op
OK: 2 passed
--- PASS: TestBench (13.54s)
=== RUN   TestT
PASS: bench_test.go:31: benchTestSuite.BenchmarkMergeSort	       1	6564105588 ns/op
PASS: bench_test.go:40: benchTestSuite.BenchmarkNormalSort	       1	6423950028 ns/op
OK: 2 passed
--- PASS: TestT (13.80s)
=== RUN   TestBench
PASS: bench_test.go:31: benchTestSuite.BenchmarkMergeSort	       1	6628816072 ns/op
PASS: bench_test.go:40: benchTestSuite.BenchmarkNormalSort	       1	6399796639 ns/op
OK: 2 passed
--- PASS: TestBench (13.76s)
=== RUN   TestT
PASS: bench_test.go:31: benchTestSuite.BenchmarkMergeSort	       1	6601064750 ns/op
PASS: bench_test.go:40: benchTestSuite.BenchmarkNormalSort	       1	6659893782 ns/op
OK: 2 passed
--- PASS: TestT (13.93s)
PASS
ok  	pingcap/talentplan/tidb/mergesort	55.057s
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/talent-plan/63)
<!-- Reviewable:end -->
