### PR TITLE
dss: fix test_get_timestamp_under_unreliable_network

### DIFF
--- a/dss/percolator/src/tests.rs
+++ b/dss/percolator/src/tests.rs
@@ -111,7 +111,7 @@ fn test_get_timestamp_under_unreliable_network() {
     rn.enable("tso2", true);
 
     for child in children {
-        let _ = child.join();
+        let _ = child.join().unwrap();
     }
 }
 


### PR DESCRIPTION
This PR fixes the test can pass even if the internal thread has panicked.