### PR TITLE
mapreduce: fix ExampleURLTop10Map comment

### DIFF
--- a/tidb/mapreduce/urltop10_example.go
+++ b/tidb/mapreduce/urltop10_example.go
@@ -48,7 +48,7 @@ func ExampleURLCountReduce(key string, values []string) string {
 	return fmt.Sprintf("%s %s\n", key, strconv.Itoa(len(values)))
 }
 
-// ExampleURLTop10Map is the map function in the first round
+// ExampleURLTop10Map is the map function in the second round
 func ExampleURLTop10Map(filename string, contents string) []KeyValue {
 	lines := strings.Split(contents, "\n")
 	kvs := make([]KeyValue, 0, len(lines))


### PR DESCRIPTION
According to the code in `ExampleURLTop10()` https://github.com/pingcap/talent-plan/blob/adb5ceb3f8a54fbcbc24bbbc010c7a4b297d5a5d/tidb/mapreduce/urltop10_example.go#L15-L30 `ExampleURLTop10Map()` is called in second round instead of first round.