### PR TITLE
dss/percolator: clippy error on let-binding a unit value

### DIFF
--- a/dss/percolator/src/tests.rs
+++ b/dss/percolator/src/tests.rs
@@ -111,7 +111,7 @@ fn test_get_timestamp_under_unreliable_network() {
     rn.enable("tso2", true);
 
     for child in children {
-        let _ = child.join().unwrap();
+        child.join().unwrap();
     }
 }
 


### PR DESCRIPTION
clippy::all implies clippy::let-unit-value. This changeset removes the let-binding of a unit value which would cause an error.