### PR TITLE
Fix try_recv() which causes panic

### DIFF
--- a/dss/src/kvraft/tests.rs
+++ b/dss/src/kvraft/tests.rs
@@ -486,7 +486,7 @@ fn generic_test_linearizability(
 
         if partitions {
             debug!("wait for partitioner");
-            partitioner_rx.try_recv().unwrap();
+            partitioner_rx.recv().unwrap();
             // reconnect network and submit a request. A client may
             // have submitted a request in a minority.  That request
             // won't return until that server discovers a new term


### PR DESCRIPTION
Using `unwrap()` for `try_recv()` can cause panic.
This seems to be a mistake, because "recv" is used in similar places：

https://github.com/pingcap/talent-plan/blob/f55dfc48139f1d945af1a8e697bb80fb6733484b/dss/src/kvraft/tests.rs#L286-L296