### PR TITLE
Fix labrpc building for Rust Nightly

### DIFF
--- a/dss/labrpc/src/lib.rs
+++ b/dss/labrpc/src/lib.rs
@@ -46,7 +46,7 @@ static ID_ALLOC: AtomicUsize = AtomicUsize::new(0);
 
 pub type RpcFuture<T> = Box<dyn Future<Item = T, Error = Error> + Send + 'static>;
 
-pub type Handler = Fn(&[u8]) -> RpcFuture<Vec<u8>>;
+pub type Handler = dyn Fn(&[u8]) -> RpcFuture<Vec<u8>>;
 
 pub trait HandlerFactory: Sync + Send + 'static {
     fn handler(&self, name: &'static str) -> Box<Handler>;
@@ -55,7 +55,7 @@ pub trait HandlerFactory: Sync + Send + 'static {
 pub struct ServerBuilder {
     name: String,
     // Service name -> service methods
-    services: HashMap<&'static str, Box<HandlerFactory>>,
+    services: HashMap<&'static str, Box<dyn HandlerFactory>>,
 }
 
 impl ServerBuilder {
@@ -69,7 +69,7 @@ impl ServerBuilder {
     pub fn add_service(
         &mut self,
         service_name: &'static str,
-        fact: Box<HandlerFactory>,
+        fact: Box<dyn HandlerFactory>,
     ) -> Result<()> {
         match self.services.entry(service_name) {
             hashbrown::hash_map::Entry::Occupied(_) => Err(Error::Other(format!(
@@ -99,7 +99,7 @@ struct ServerCore {
     name: String,
     id: usize,
 
-    services: HashMap<&'static str, Box<HandlerFactory>>,
+    services: HashMap<&'static str, Box<dyn HandlerFactory>>,
     count: AtomicUsize,
 }
 

--- a/dss/src/kvraft/tests.rs
+++ b/dss/src/kvraft/tests.rs
@@ -95,7 +95,7 @@ fn check_clnt_appends(clnt: usize, v: String, count: usize) {
             assert_eq!(off1, off, "duplicate element {:?} in Append result", wanted);
 
             if let Some(lastoff) = lastoff {
-                assert!( off > lastoff "wrong order for element {:?} in Append result", wanted);
+                assert!( off > lastoff, "wrong order for element {:?} in Append result", wanted);
             }
             lastoff = Some(off);
         } else {
@@ -120,7 +120,7 @@ fn check_concurrent_appends(v: String, counts: &[usize]) {
                 assert_eq!(off1, off, "duplicate element {:?} in Append result", wanted);
 
                 if let Some(lastoff) = lastoff {
-                    assert!( off > lastoff "wrong order for element {:?} in Append result", wanted);
+                    assert!( off > lastoff, "wrong order for element {:?} in Append result", wanted);
                 }
                 lastoff = Some(off);
             } else {

--- a/dss/src/raft/mod.rs
+++ b/dss/src/raft/mod.rs
@@ -199,17 +199,16 @@ impl Node {
 
     /// the service using Raft (e.g. a k/v server) wants to start
     /// agreement on the next command to be appended to Raft's log. if this
-    /// server isn't the leader, returns false. otherwise start the
-    /// agreement and return immediately. there is no guarantee that this
+    /// server isn't the leader, returns [`Error::NotLeader`]. otherwise start
+    /// the agreement and return immediately. there is no guarantee that this
     /// command will ever be committed to the Raft log, since the leader
     /// may fail or lose an election. even if the Raft instance has been killed,
     /// this function should return gracefully.
     ///
-    /// the first return value is the index that the command will appear at
-    /// if it's ever committed. the second return value is the current
-    /// term. the third return value is true if this server believes it is
-    /// the leader.
-    /// This method must return quickly.
+    /// the first value of the tuple is the index that the command will appear
+    /// at if it's ever committed. the second is the current term. 
+    /// 
+    /// This method must return without blocking on the raft.
     pub fn start<M>(&self, command: &M) -> Result<(u64, u64)>
     where
         M: labcodec::Message,


### PR DESCRIPTION
Missing `dyn` for trait object (bare trait object) is a warning by default now as rust-lang/rust#61203 is merged, which breaks labrpc.
Also fixed a few other warnings and unclear documents.
