### PR TITLE
Rust: Fix uncompacted is not reset after a compaction

### DIFF
--- a/rust/projects/networking/src/engines/kvs.rs
+++ b/rust/projects/networking/src/engines/kvs.rs
@@ -120,6 +120,8 @@ impl KvStore {
             fs::remove_file(log_path(&self.path, stale_gen))?;
         }
 
+        self.uncompacted = 0;
+
         Ok(())
     }
 


### PR DESCRIPTION
Tiny bug fix of Project 3 code