### PR TITLE
Expand top-level README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,47 @@
 # PingCAP Talent Plan
 
-## TiDB Part
+This is a series of training courses about writing distributed systems in Go and
+Rust. It is maintained by PingCAP for training and/or evaluating students, new
+employees, and new contributors to [TiDB] and [TiKV]. As such, the courses focus
+on subjects relevant to those projects. They are though appropriate for all Go
+and Rust programmers &mdash; they do not require any knowledge of or interest in
+either TiDB or TiKV.
 
-* Week 1: [Merge Sort](./tidb/mergesort)
-* Week 2: [Map Reduce](./tidb/mapreduce)
-* Week 4: [Parallel Join](./tidb/join)
+The courses primarily consist of projects (or "labs") where coding problems are
+presented, along with a partial implementation or API description, and a test
+suite.
 
-## TiKV Part
+Each course is developed independently, so they vary in their presentation and
+their expectations from course-takers. See the individual course documentation
+for details.
+
+[TiDB]: https://github.com/pingcap/tidb
+[TiKV]: https://github.com/tikv/tikv
+
+
+## Training courses
+
+- **[Practical Networked Applications in Rust][rust]**. A series of projects
+  that incrementally develop a single Rust project from the ground up into a
+  high-performance, networked, parallel and asynchronous key/value store. Along
+  the way various real-world and practical Rust development subject matter are
+  explored and discussed. Knowledge of the subject matter can be considered a
+  prerequisite to Distributed Systems in Rust.
+
+- **[Distributed Systems in Rust][dss]**. Adapted from the [MIT 6.824]
+  distributed systems coursework, this course focuses on implementing important
+  distributed algorithms, including the [Raft] consensus algorithm.
+
+- **[Distributed Systems in Go][tidb]**. Distributed systems algorithms in Go.
+
+[rust]: ./rust/
+[dss]: ./dss/
+[tidb]: ./tidb/
+
+[MIT 6.824]: http://nil.csail.mit.edu/6.824/2017/index.html
+[Raft]: https://raft.github.io/
+
+## License
+
+These courses may be freely used and modified for any purpose, under the terms
+of each course's individual license. See the courses for details.

--- a/tidb/README.md
+++ b/tidb/README.md
@@ -1,0 +1,6 @@
+# Distributed Systems in Go
+
+* Week 1: [Merge Sort](./tidb/mergesort)
+* Week 2: [Map Reduce](./tidb/mapreduce)
+* Week 4: [Parallel Join](./tidb/join)
+


### PR DESCRIPTION
Move TiDB course details into its own README.

This adds a description of what's in the repo, brief descriptions of the courses, and links to the individual courses for further information.

I took the liberty of giving titles to the dss and tidb courses: "Distributed Systems in Rust", and "Distributed Systems in Go". This makes at least the titles of the three courses stylistically consistent. You'll note that the changes here push toward being PingCAP-agnostic. I do not want to limit the audience, scaring away potential users and contributors, by appearing to be PingCAP-specific (in the same vein I would prefer to [change the repo name](https://github.com/pingcap/talent-plan/issues/107).

Because I am only familiar with the Rust course, it has the most detailed description. Please do improve the dss and tidb course descriptions in follow up PRs.

Because there will be a batch of students using this repo Monday, and it is currently a China holiday, I intend to merge this by Monday regardless of its review status. This won't mean I'm not willing to changing anything here, just that I need the repo to have a nicer presentation quickly.

[Rendered](https://github.com/brson/talent-training/tree/readme).

PTAL @overvenus @nolouch @shenli. cc @sticnarf @mapleFU 

