### PR TITLE
Fix broken links in README.md

### DIFF
--- a/tidb/README.md
+++ b/tidb/README.md
@@ -1,6 +1,6 @@
 # Distributed Systems in Go
 
-* Week 1: [Merge Sort](./tidb/mergesort)
-* Week 2: [Map Reduce](./tidb/mapreduce)
-* Week 4: [Parallel Join](./tidb/join)
+* Week 1: [Merge Sort](./mergesort)
+* Week 2: [Map Reduce](./mapreduce)
+* Week 4: [Parallel Join](./join)
 


### PR DESCRIPTION
They were producing an extra /tidb/ in the URL.