### PR TITLE
rust/projects/project-3/project.md: Remove --release reference

### DIFF
--- a/rust/projects/project-3/project.md
+++ b/rust/projects/project-3/project.md
@@ -443,8 +443,7 @@ Random numbers can be generated with the [`rand`] crate.
 
 [`rand`]: https://docs.rs/crate/rand/
 
-Once you have your benchmamrks, run them with `cargo bench --release`. Note
-the `--release` argument &mdash; unoptimized benchmarking is mostly useless!
+Once you have your benchmamrks, run them with `cargo bench`.
 
 _Write the above benchmarks, and compare the results between `kvs` and `sled`._
 


### PR DESCRIPTION
`cargo bench` does not support the `--release` flag. According to the
Cargo book [1]:

> Benchmarks are always built with the bench profile. Binary and lib
> targets are built separately as benchmarks with the bench profile.
> Library targets are built with the release profiles when linked to
> binaries and benchmarks. Dependencies use the release profile.

```bash
$ cargo --version
cargo 1.36.0 (c4fcfb725 2019-05-15)

$ cargo bench --release
error: Found argument '--release' which wasn't expected, or isn't valid
in this context

USAGE:
    cargo bench [OPTIONS] [BENCHNAME] [-- <args>...]

For more information try --help
```

[1]
https://doc.rust-lang.org/cargo/commands/cargo-bench.html#cargo-bench