### PR TITLE
Fix broken TiKV deep dive link

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -132,7 +132,7 @@ discretion.
 [CONTRIBUTING.md]: CONTRIBUTING.md
 [CC-BY 4.0]: https://opendefinition.org/licenses/cc-by/
 [MIT]: https://opensource.org/licenses/MIT
-[Deep Dive TiKV]: https://tikv.org/deep-dive/
+[Deep Dive TiKV]: https://tikv.org/docs/deep-dive/introduction/
 [Distributed Systems in Rust]: https://github.com/pingcap/talent-plan/tree/master/dss
 [NewSQL]: https://en.wikipedia.org/wiki/NewSQL
 [NoSQL]: https://www.thoughtworks.com/insights/blog/nosql-databases-overview


### PR DESCRIPTION
The original link https://tikv.org/deep-dive/ does not exist anymore, replace with the correct one https://tikv.org/docs/deep-dive/introduction/.

Fix #262 .