### PR TITLE
Remove --release flag to cargo bench

### DIFF
--- a/rust/projects/project-4/project.md
+++ b/rust/projects/project-4/project.md
@@ -627,8 +627,7 @@ Call this benchmark `read_queued_kvstore` (or whatever).
 
 **Whew. That was a lot of work**.
 
-So you can run this set of criterion benchmarks as usual with `cargo bench
---release`.
+So you can run this set of criterion benchmarks as usual with `cargo bench`.
 
 <!-- TODO show example results -->
 


### PR DESCRIPTION
Remove `--release` flag to cargo bench as it's not supported.