### PR TITLE
Project-3 & 4: Fix sled test cli_access_server_sled_engine

### DIFF
--- a/rust/projects/project-3/tests/cli.rs
+++ b/rust/projects/project-3/tests/cli.rs
@@ -294,6 +294,7 @@ fn cli_access_server(engine: &str, addr: &str) {
     sender.send(()).unwrap();
     handle.join().unwrap();
 
+    thread::sleep(Duration::from_millis(500));
     // Reopen and check value
     let (sender, receiver) = mpsc::sync_channel(0);
     let mut server = Command::cargo_bin("kvs-server").unwrap();

--- a/rust/projects/project-4/tests/cli.rs
+++ b/rust/projects/project-4/tests/cli.rs
@@ -294,6 +294,7 @@ fn cli_access_server(engine: &str, addr: &str) {
     sender.send(()).unwrap();
     handle.join().unwrap();
 
+    thread::sleep(Duration::from_millis(500));
     // Reopen and check value
     let (sender, receiver) = mpsc::sync_channel(0);
     let mut server = Command::cargo_bin("kvs-server").unwrap();


### PR DESCRIPTION
The sled test in cli_access_server fails because the second connection attempt
is made too fast after killing the first server.

Verified with
  - rustc 1.37 as well as current 1.39.0-nightly (9af17757b 2019-09-02)
  - in both Project-3 and 4
  - and the given example solution and my own implementation

System is running Void Linux on a i5-5200U.

```
thread 'main' panicked at 'should be `able` to open configured file at "/tmp/.tmpX9hOJN/db";
IO error: could not acquire appropriate file lock on "/tmp/.tmpX9hOJN/db":
Os { code: 11, kind: WouldBlock, message: "Resource temporarily unavailable" }',
/home/suka/.cargo/registry/src/github.com-1ecc6299db9ec823/pagecache-0.19.1/src/config.rs:202:13
```

Inserting a minimal delay of at least 30ms here solves the issues in all the
combinations mentioned above. Other config options in sled itself did not help.