### PR TITLE
raft: deny unused variables, dead code, and missing doc

### DIFF
--- a/dss/Makefile
+++ b/dss/Makefile
@@ -5,7 +5,7 @@ export RUST_BACKTRACE=1
 LOG_LEVEL ?= raft=info,percolator=info
 
 check:
-	cargo fmt --all
+	cargo fmt --all -- --check
 	cargo clippy --all --tests -- -D clippy::all
 
 test: test_others test_2 test_3

--- a/dss/raft/src/kvraft/client.rs
+++ b/dss/raft/src/kvraft/client.rs
@@ -9,7 +9,7 @@ enum Op {
 
 pub struct Clerk {
     pub name: String,
-    servers: Vec<KvClient>,
+    pub servers: Vec<KvClient>,
     // You will have to modify this struct.
 }
 
@@ -22,7 +22,8 @@ impl fmt::Debug for Clerk {
 impl Clerk {
     pub fn new(name: String, servers: Vec<KvClient>) -> Clerk {
         // You'll have to add code here.
-        Clerk { name, servers }
+        // Clerk { name, servers }
+        crate::your_code_here((name, servers))
     }
 
     /// fetch the current value for a key.

--- a/dss/raft/src/kvraft/client.rs
+++ b/dss/raft/src/kvraft/client.rs
@@ -33,7 +33,7 @@ impl Clerk {
     // let reply = self.servers[i].get(args).unwrap();
     pub fn get(&self, key: String) -> String {
         // You will have to modify this function.
-        unimplemented!()
+        crate::your_code_here(key)
     }
 
     /// shared by Put and Append.
@@ -42,7 +42,7 @@ impl Clerk {
     // let reply = self.servers[i].put_append(args).unwrap();
     fn put_append(&self, op: Op) {
         // You will have to modify this function.
-        unimplemented!()
+        crate::your_code_here(op)
     }
 
     pub fn put(&self, key: String, value: String) {

--- a/dss/raft/src/kvraft/config.rs
+++ b/dss/raft/src/kvraft/config.rs
@@ -230,16 +230,6 @@ impl Config {
         }
     }
 
-    pub fn disconnect_client(&self, ck: &client::Clerk, from: &[usize]) {
-        debug!("DisconnectClient {:?} from {:?}", ck, from);
-        let clerks = self.clerks.lock().unwrap();
-        let endnames = &clerks[&ck.name];
-        for j in from {
-            let s = &endnames[*j];
-            self.net.enable(s, false);
-        }
-    }
-
     /// Shutdown a server by isolating it
     pub fn shutdown_server(&self, i: usize) {
         let mut servers = self.servers.lock().unwrap();

--- a/dss/raft/src/kvraft/server.rs
+++ b/dss/raft/src/kvraft/server.rs
@@ -33,6 +33,15 @@ impl KvServer {
     }
 }
 
+impl KvServer {
+    /// Only for suppressing deadcode warnings.
+    #[doc(hidden)]
+    pub fn __suppress_deadcode(&mut self) {
+        let _ = &self.me;
+        let _ = &self.maxraftstate;
+    }
+}
+
 // Choose concurrency paradigm.
 //
 // You can either drive the kv server by the rpc framework,

--- a/dss/raft/src/kvraft/server.rs
+++ b/dss/raft/src/kvraft/server.rs
@@ -24,11 +24,12 @@ impl KvServer {
         let (tx, apply_ch) = unbounded();
         let rf = raft::Raft::new(servers, me, persister, tx);
 
-        KvServer {
-            me,
-            maxraftstate,
-            rf: raft::Node::new(rf),
-        }
+        crate::your_code_here((rf, maxraftstate, apply_ch))
+        // KvServer {
+        //     me,
+        //     maxraftstate,
+        //     rf: raft::Node::new(rf),
+        // }
     }
 }
 
@@ -54,7 +55,7 @@ pub struct Node {
 impl Node {
     pub fn new(kv: KvServer) -> Node {
         // Your code here.
-        Node {}
+        crate::your_code_here(kv);
     }
 
     /// the tester calls Kill() when a KVServer instance won't
@@ -86,11 +87,11 @@ impl Node {
 impl KvService for Node {
     fn get(&self, arg: GetRequest) -> RpcFuture<GetReply> {
         // Your code here.
-        unimplemented!()
+        crate::your_code_here(arg)
     }
 
     fn put_append(&self, arg: PutAppendRequest) -> RpcFuture<PutAppendReply> {
         // Your code here.
-        unimplemented!()
+        crate::your_code_here(arg)
     }
 }

--- a/dss/raft/src/kvraft/server.rs
+++ b/dss/raft/src/kvraft/server.rs
@@ -25,11 +25,6 @@ impl KvServer {
         let rf = raft::Raft::new(servers, me, persister, tx);
 
         crate::your_code_here((rf, maxraftstate, apply_ch))
-        // KvServer {
-        //     me,
-        //     maxraftstate,
-        //     rf: raft::Node::new(rf),
-        // }
     }
 }
 

--- a/dss/raft/src/kvraft/tests.rs
+++ b/dss/raft/src/kvraft/tests.rs
@@ -59,7 +59,7 @@ where
     let mut cas = Vec::with_capacity(ncli);
     for cli in 0..ncli {
         let (tx, rx) = oneshot::channel();
-        cas.push(rx.map(move |e| {
+        cas.push(rx.map(move |_| {
             debug!("spawn_clients_and_wait: client {} is done", cli);
         }));
 
@@ -113,11 +113,12 @@ fn check_clnt_appends(clnt: usize, v: String, count: usize) {
 
 // check that all known appends are present in a value,
 // and are in order for each concurrent client.
+#[allow(clippy::needless_range_loop)]
 fn check_concurrent_appends(v: String, counts: &[usize]) {
     let nclients = counts.len();
     for i in 0..nclients {
         let mut lastoff = None;
-        for (j, count) in counts.iter().enumerate() {
+        for j in 0..counts[i] {
             let wanted = format!("x {} {} y", i, j);
             if let Some(off) = v.find(&wanted) {
                 let off1 = v.rfind(&wanted).unwrap();
@@ -225,7 +226,7 @@ fn generic_test(
     let done_clients = Arc::new(AtomicUsize::new(0));
     let mut clnt_txs = vec![];
     let mut clnt_rxs = vec![];
-    for i in 0..nclients {
+    for _ in 0..nclients {
         let (tx, rx) = mpsc::channel();
         clnt_txs.push(tx);
         clnt_rxs.push(rx);
@@ -395,7 +396,7 @@ fn generic_test_linearizability(
     let done_clients = Arc::new(AtomicUsize::new(0));
     let mut clnt_txs = vec![];
     let mut clnt_rxs = vec![];
-    for i in 0..nclients {
+    for _ in 0..nclients {
         let (tx, rx) = mpsc::channel();
         clnt_txs.push(tx);
         clnt_rxs.push(rx);
@@ -521,7 +522,7 @@ fn generic_test_linearizability(
         }
 
         // wait for clients.
-        for (i, clnt_rx) in clnt_rxs.iter().enumerate() {
+        for clnt_rx in &clnt_rxs {
             clnt_rx.recv().unwrap();
         }
 
@@ -847,7 +848,7 @@ fn test_snapshot_size_3b() {
 
     cfg.begin("Test: snapshot size is reasonable (3B)");
 
-    for i in 0..200 {
+    for _ in 0..200 {
         put(&cfg, &ck, "x", "0");
         check(&cfg, &ck, "x", "0");
         put(&cfg, &ck, "x", "1");

--- a/dss/raft/src/lib.rs
+++ b/dss/raft/src/lib.rs
@@ -1,7 +1,5 @@
 #![feature(integer_atomics)]
 #![deny(clippy::all)]
-// You need to remove these two allows.
-#![allow(dead_code)]
 
 #[allow(unused_imports)]
 #[macro_use]
@@ -10,9 +8,9 @@ extern crate log;
 #[macro_use]
 extern crate prost_derive;
 
-mod kvraft;
+pub mod kvraft;
 mod proto;
-mod raft;
+pub mod raft;
 
 /// A place holder for suppressing unused_variables warning.
 fn your_code_here<T>(_: T) -> ! {

--- a/dss/raft/src/lib.rs
+++ b/dss/raft/src/lib.rs
@@ -2,7 +2,6 @@
 #![deny(clippy::all)]
 // You need to remove these two allows.
 #![allow(dead_code)]
-#![allow(unused_variables)]
 
 #[allow(unused_imports)]
 #[macro_use]
@@ -14,3 +13,8 @@ extern crate prost_derive;
 mod kvraft;
 mod proto;
 mod raft;
+
+/// A place holder for suppressing unused_variables warning.
+fn your_code_here<T>(_: T) -> ! {
+    unimplemented!()
+}

--- a/dss/raft/src/raft/mod.rs
+++ b/dss/raft/src/raft/mod.rs
@@ -82,7 +82,6 @@ impl Raft {
         rf.restore(&raft_state);
 
         crate::your_code_here((rf, apply_ch))
-        // rf
     }
 
     /// save Raft's persistent state to stable storage,
@@ -208,7 +207,6 @@ impl Node {
     pub fn new(raft: Raft) -> Node {
         // Your code here.
         crate::your_code_here(raft)
-        // Node {}
     }
 
     /// the service using Raft (e.g. a k/v server) wants to start

--- a/dss/raft/src/raft/mod.rs
+++ b/dss/raft/src/raft/mod.rs
@@ -170,6 +170,20 @@ impl Raft {
     }
 }
 
+impl Raft {
+    /// Only for suppressing deadcode warnings.
+    #[doc(hidden)]
+    pub fn __suppress_deadcode(&mut self) {
+        let _ = self.start(&0);
+        let _ = self.send_request_vote(0, &Default::default());
+        self.persist();
+        let _ = &self.state;
+        let _ = &self.me;
+        let _ = &self.persister;
+        let _ = &self.peers;
+    }
+}
+
 // Choose concurrency paradigm.
 //
 // You can either drive the raft state machine by the rpc framework,

--- a/dss/raft/src/raft/mod.rs
+++ b/dss/raft/src/raft/mod.rs
@@ -81,7 +81,8 @@ impl Raft {
         // initialize from state persisted before a crash
         rf.restore(&raft_state);
 
-        rf
+        crate::your_code_here((rf, apply_ch))
+        // rf
     }
 
     /// save Raft's persistent state to stable storage,
@@ -192,7 +193,8 @@ impl Node {
     /// Create a new raft service.
     pub fn new(raft: Raft) -> Node {
         // Your code here.
-        Node {}
+        crate::your_code_here(raft)
+        // Node {}
     }
 
     /// the service using Raft (e.g. a k/v server) wants to start
@@ -214,7 +216,7 @@ impl Node {
         // Your code here.
         // Example:
         // self.raft.start(command)
-        unimplemented!()
+        crate::your_code_here(command)
     }
 
     /// The current term of this peer.
@@ -222,7 +224,7 @@ impl Node {
         // Your code here.
         // Example:
         // self.raft.term
-        unimplemented!()
+        crate::your_code_here(())
     }
 
     /// Whether this peer believes it is the leader.
@@ -230,7 +232,7 @@ impl Node {
         // Your code here.
         // Example:
         // self.raft.leader_id == self.id
-        unimplemented!()
+        crate::your_code_here(())
     }
 
     /// The current state of this peer.
@@ -258,6 +260,6 @@ impl RaftService for Node {
     // example RequestVote RPC handler.
     fn request_vote(&self, args: RequestVoteArgs) -> RpcFuture<RequestVoteReply> {
         // Your code here (2A, 2B).
-        unimplemented!()
+        crate::your_code_here(args)
     }
 }

--- a/dss/raft/src/raft/persister.rs
+++ b/dss/raft/src/raft/persister.rs
@@ -44,6 +44,7 @@ impl<T: ?Sized + Sync + Persister> Persister for Arc<T> {
     }
 }
 
+#[derive(Default)]
 pub struct SimplePersister {
     states: Mutex<(
         Vec<u8>, // raft state


### PR DESCRIPTION
Deny unused variables, dead code, and missing doc