### PR TITLE
reproducible builds by specifying rustc toolchain

### DIFF
--- a/dss/raft/README.md
+++ b/dss/raft/README.md
@@ -24,8 +24,7 @@ and other resource. Those material should be helpful for you to complete this la
 
 First, please clone this repository with `git` to get the source code of the labs.
 
-Then, make sure you have `rustup` install, and override toolchain for this folder
-to nightly with `rustup override set nightly` . Also, to make things simpler you
+Then, make sure you have `rustup` installed. Also, to make things simpler you
 should have `make` installed.
 
 Now you can run `make test_others` to check that things are going right. You

--- a/dss/rust-toolchain
+++ b/dss/rust-toolchain
@@ -1,1 +1,1 @@
-nightly-2019-09-03-x86_64-apple-darwin
+nightly-2019-09-03

--- a/dss/rust-toolchain
+++ b/dss/rust-toolchain
@@ -1,0 +1,1 @@
+nightly-2019-09-03-x86_64-apple-darwin


### PR DESCRIPTION
I ran into a few problems when trying to get the project to build with nightly:
- not all versions support `clippy` and `fmt` https://rust-lang.github.io/rustup-components-history/
- newer versions of `clippy` have additional warnings, which cause previous code to fail

I have found that when using nightly this can all be avoided if you specify a `rust-toolchain` file. The following code compiles/tests pass locally with the specified toolchain (latest with clippy and fmt).