### PR TITLE
Update slack invite link

### DIFF
--- a/rust/CONTRIBUTING.md
+++ b/rust/CONTRIBUTING.md
@@ -19,8 +19,7 @@ the Rust course are tagged `p: rust`. The `help wanted` and `good first issue`
 tags may help you find something interesting.
 
 [issue tracker]: https://github.com/pingcap/talent-plan/issues/
-[TiKV Slack]: https://join.slack.com/t/tikv-wg/shared_invite/enQtNTUyODE4ODU2MzI0LTgzZDQ3NzZlNDkzMGIyYjU1MTA0NzIwMjFjODFiZjA0YjFmYmQyOTZiNzNkNzg1N2U1MDdlZTIxNTU5NWNhNjk
-
+[TiKV Slack]: https://join.slack.com/t/tikv-wg/shared_invite/enQtNTUyODE4ODU2MzI0LWVlMWMzMDkyNWE5ZjY1ODAzMWUwZGVhNGNhYTc3MzJhYWE0Y2FjYjliYzY1OWJlYTc4OWVjZWM1NDkwN2QxNDE
 
 ## Developing a new project
 

--- a/rust/docs/lesson-plan.md
+++ b/rust/docs/lesson-plan.md
@@ -321,7 +321,7 @@ to know where to go next on that path? We've got [some ideas][n].
 [Rust Discord]: https://discord.gg/rust-lang
 [Rust meetup]: https://www.meetup.com/topics/rust
 [StackOverflow]: https://stackoverflow.com/questions/tagged/rust
-[TiKV Slack]: https://join.slack.com/t/tikv-wg/shared_invite/enQtNTUyODE4ODU2MzI0LTgzZDQ3NzZlNDkzMGIyYjU1MTA0NzIwMjFjODFiZjA0YjFmYmQyOTZiNzNkNzg1N2U1MDdlZTIxNTU5NWNhNjk
+[TiKV Slack]: https://join.slack.com/t/tikv-wg/shared_invite/enQtNTUyODE4ODU2MzI0LWVlMWMzMDkyNWE5ZjY1ODAzMWUwZGVhNGNhYTc3MzJhYWE0Y2FjYjliYzY1OWJlYTc4OWVjZWM1NDkwN2QxNDE
 [author]: https://github.com/brson/
 [brson]: https://github.com/brson/
 [kv]: https://en.wikipedia.org/wiki/Key-value_database


### PR DESCRIPTION
The link to join the TiKV's Slack is outdated. Students trying to get
help can get a Slack's error page.

This commit uses the same invite link used on the tikv/tikv project and
updated on tikv/tikv#5530.