### PR TITLE
rust/building-blocks: change BB3's exercise helping link on serde docs

### DIFF
--- a/rust/building-blocks/bb-3.md
+++ b/rust/building-blocks/bb-3.md
@@ -34,7 +34,7 @@ Read all the readings and perform all the exercises.
 
 - **Exercise: Write a Redis ping-pong client and server with serialized
   messages**. Same as above, but this time define the protocol with types and
-  use [`serde` custom serialization][cs] to indirectly read and write messages
+  write a [`serde` data format][df] to indirectly read and write messages
   through serialization.
 
 - **[Reading: Statistically Rigorous Java Performance Evaluation][pe]**.
@@ -46,7 +46,7 @@ Read all the readings and perform all the exercises.
 <!-- TODO: something about traits? -->
 
 [pe]: https://dri.es/files/oopsla07-georges.pdf
-[cs]: https://serde.rs/custom-serialization.html
+[df]: https://serde.rs/data-format.html
 [`std::io`]: https://doc.rust-lang.org/std/io/
 [PING]: https://redis.io/commands/ping
 [commands]: https://redis.io/commands


### PR DESCRIPTION
BB3's exercise points to Custom Serialization. The exercise consists of
using serde to serialize and deserialize redis protocol messages. For this
purpose it's necessary writing a new serde's data format, making it able to
serialize and deserialize redis protocol's messages.

This commit updates BB3's exercise mentioned above and points the
helping link for serde's documentation about writing a data format.

Discussed on tikv-wg slack on:
- https://tikv-wg.slack.com/archives/CKD9363A8/p1573310455016400
- https://tikv-wg.slack.com/archives/CKD9363A8/p1574274353032000