### PR TITLE
rust/project-4: fix dead code in KvStore::open()

### DIFF
--- a/rust/projects/project-4/src/engines/kvs.rs
+++ b/rust/projects/project-4/src/engines/kvs.rs
@@ -76,7 +76,7 @@ impl KvStore {
         let reader = KvStoreReader {
             path: Arc::clone(&path),
             safe_point,
-            readers: RefCell::new(BTreeMap::new()),
+            readers: RefCell::new(readers),
         };
 
         let writer = KvStoreWriter {


### PR DESCRIPTION
In KvStore::open(), `readers` is just inserted after initialization, then left there and finally dropped.
We can either delete related codes or use it for constructing KvStoreReader.