### PR TITLE
dss: Update to latest dependencies doc links

### DIFF
--- a/courses/dss/raft/README.md
+++ b/courses/dss/raft/README.md
@@ -127,12 +127,12 @@ syntax of the log level. Also, you can collect the output in a file by redirecti
 the output to a file like `make test_2a 2>test.log`
 
 [prost]:https://github.com/danburkert/prost
-[futures]:https://docs.rs/futures/0.1/futures/
+[futures]:https://docs.rs/futures/0.3/futures/index.html
 [sleep]:https://doc.rust-lang.org/std/thread/fn.sleep.html
-[futures-timer]:https://docs.rs/futures-timer/0.1/futures_timer/index.html
-[rand]:https://docs.rs/rand/0.4/rand/
+[futures-timer]:https://docs.rs/futures-timer/3.0/futures_timer/index.html
+[rand]:https://docs.rs/rand/0.7/rand/index.html
 [log]:https://docs.rs/log/0.4/log/
-[env_logger]:https://docs.rs/env_logger/0.6/env_logger/
+[env_logger]:https://docs.rs/env_logger/0.7/env_logger/
 
 ### Part 2B
 


### PR DESCRIPTION
<!-- Thank you for contributing to talent-plan!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

- Breif description of the problem:

This [commit](https://github.com/pingcap/talent-plan/commit/4c74c3653fd4bb3388138e2d4260a44dc9f2a131) update all dependencies but the corresponding doc links in `courses/dss/README.md` are still old.

### What is changed and how it works?

I update all old version dependencies links to the latest in `courses/dss/README.md`.(Version codes same as `Cargo.toml`)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code
