### PR TITLE
fix(courses/rust/project-2): BufWriterWithPos seek end of file

### DIFF
--- a/courses/rust/projects/project-2/src/kv.rs
+++ b/courses/rust/projects/project-2/src/kv.rs
@@ -350,7 +350,7 @@ struct BufWriterWithPos<W: Write + Seek> {
 
 impl<W: Write + Seek> BufWriterWithPos<W> {
     fn new(mut inner: W) -> Result<Self> {
-        let pos = inner.seek(SeekFrom::Current(0))?;
+        let pos = inner.seek(SeekFrom::End(0))?;
         Ok(BufWriterWithPos {
             writer: BufWriter::new(inner),
             pos,


### PR DESCRIPTION
When opening a file with append, although writing the file starts from the end,
the result of seeking the current position does start, and it needs to specifiy seek
to the end of the file.