### PR TITLE
Using 'unwrap()' instead of 'expect("msg")'

### DIFF
--- a/courses/rust/projects/project-2/src/bin/kvs.rs
+++ b/courses/rust/projects/project-2/src/bin/kvs.rs
@@ -35,14 +35,14 @@ fn main() -> Result<()> {
 
     match matches.subcommand() {
         ("set", Some(matches)) => {
-            let key = matches.value_of("KEY").expect("KEY argument missing");
-            let value = matches.value_of("VALUE").expect("VALUE argument missing");
+            let key = matches.value_of("KEY").unwrap();
+            let value = matches.value_of("VALUE").unwrap();
 
             let mut store = KvStore::open(current_dir()?)?;
             store.set(key.to_string(), value.to_string())?;
         }
         ("get", Some(matches)) => {
-            let key = matches.value_of("KEY").expect("KEY argument missing");
+            let key = matches.value_of("KEY").unwrap();
 
             let mut store = KvStore::open(current_dir()?)?;
             if let Some(value) = store.get(key.to_string())? {
@@ -52,7 +52,7 @@ fn main() -> Result<()> {
             }
         }
         ("rm", Some(matches)) => {
-            let key = matches.value_of("KEY").expect("KEY argument missing");
+            let key = matches.value_of("KEY").unwrap();
 
             let mut store = KvStore::open(current_dir()?)?;
             match store.remove(key.to_string()) {


### PR DESCRIPTION
### What problem does this PR solve?
Previously used `.expect()` calls would never be called. Since given arguments are defined as required, `clap` gives us a guarantee that code inside of `match` branches will not be called unless all required arguments are given by user.

### What is changed and how it works?
`.expect()` calls are changed to `.unwrap()` calls.

### Tests
As it's a documented behavior of `clap` library as far as I understand there is no need to cover such case with tests.