### PR TITLE
fix bug (courses/dss): remove unnecessary nested match from clippy

### DIFF
--- a/courses/dss/raft/src/raft/tests.rs
+++ b/courses/dss/raft/src/raft/tests.rs
@@ -689,11 +689,9 @@ fn test_figure_8_2c() {
         let mut leader = None;
         for i in 0..servers {
             let mut rafts = cfg.rafts.lock().unwrap();
-            if let Some(raft) = rafts.get_mut(i) {
-                if let Some(raft) = raft {
-                    if raft.start(&random_entry(&mut random)).is_ok() {
-                        leader = Some(i);
-                    }
+            if let Some(Some(raft)) = rafts.get_mut(i) {
+                if raft.start(&random_entry(&mut random)).is_ok() {
+                    leader = Some(i);
                 }
             }
         }


### PR DESCRIPTION
<!-- Thank you for contributing to talent-plan!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

- Breif description of the problem:

For the raft lab, when compiling with rustc 1.50.0, clippy issues the error: `Unnecessary nested match` for the file raft/src/raft/tests.rs:693:17.


### What is changed and how it works?
The original code is
```
            if let Some(Some(raft)) = rafts.get_mut(i) {
                if let Some(raft) = raft {
                    if raft.start(&random_entry(&mut random)).is_ok() {
                        leader = Some(i);
                    }
                }
            }
```
The code has been changed to
```
            if let Some(Some(raft)) = rafts.get_mut(i) {
                if raft.start(&random_entry(&mut random)).is_ok() {
                    leader = Some(i);
                }
            }
```
By reducing nested match, the error is fixed.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
The test of raft lab is applied
```
make test_others
```

Side effects

 - None
 
Related changes

 - Need to update the documentation
