### PR TITLE
fix bug (courses/dss):  remove duplicate clippy setting. remove unnecessary nested match. update Op enum field names contain a capitalized acronym.

### DIFF
--- a/courses/dss/linearizability/src/models.rs
+++ b/courses/dss/linearizability/src/models.rs
@@ -4,9 +4,9 @@ use super::model::{EventKind, Events, Model, Operations};
 
 #[derive(Clone, Debug)]
 pub enum Op {
-    GET,
-    PUT,
-    APPEND,
+    Get,
+    Put,
+    Append,
 }
 
 #[derive(Clone, Debug)]
@@ -84,9 +84,9 @@ impl Model for KvModel {
         output: &Self::Output,
     ) -> (bool, Self::State) {
         match input.op {
-            Op::GET => (&output.value == state, state.clone()),
-            Op::PUT => (true, input.value.clone()),
-            Op::APPEND => (true, state.clone() + &input.value),
+            Op::Get => (&output.value == state, state.clone()),
+            Op::Put => (true, input.value.clone()),
+            Op::Append => (true, state.clone() + &input.value),
         }
     }
 }
@@ -152,7 +152,7 @@ mod tests {
                 events.push(Event {
                     kind: EventKind::CallEvent,
                     value: Value::Input(KvInput {
-                        op: Op::GET,
+                        op: Op::Get,
                         key: args[2].to_string(),
                         value: "".to_string(),
                     }),
@@ -164,7 +164,7 @@ mod tests {
                 events.push(Event {
                     kind: EventKind::CallEvent,
                     value: Value::Input(KvInput {
-                        op: Op::PUT,
+                        op: Op::Put,
                         key: args[2].to_string(),
                         value: args[3].to_string(),
                     }),
@@ -176,7 +176,7 @@ mod tests {
                 events.push(Event {
                     kind: EventKind::CallEvent,
                     value: Value::Input(KvInput {
-                        op: Op::APPEND,
+                        op: Op::Append,
                         key: args[2].to_string(),
                         value: args[3].to_string(),
                     }),

--- a/courses/dss/raft/src/kvraft/config.rs
+++ b/courses/dss/raft/src/kvraft/config.rs
@@ -357,10 +357,8 @@ impl Config {
 impl Drop for Config {
     fn drop(&mut self) {
         let servers = self.servers.lock().unwrap();
-        for s in &servers.kvservers {
-            if let Some(s) = s {
-                s.kill();
-            }
+        for s in servers.kvservers.iter().flatten() {
+            s.kill();
         }
     }
 }

--- a/courses/dss/raft/src/kvraft/tests.rs
+++ b/courses/dss/raft/src/kvraft/tests.rs
@@ -433,7 +433,7 @@ fn generic_test_linearizability(
                             j += 1;
                             (
                                 KvInput {
-                                    op: Op::APPEND,
+                                    op: Op::Append,
                                     key,
                                     value: nv,
                                 },
@@ -446,7 +446,7 @@ fn generic_test_linearizability(
                             j += 1;
                             (
                                 KvInput {
-                                    op: Op::PUT,
+                                    op: Op::Put,
                                     key,
                                     value: nv,
                                 },
@@ -458,7 +458,7 @@ fn generic_test_linearizability(
                             let v = get(&cfg1, myck, &key);
                             (
                                 KvInput {
-                                    op: Op::GET,
+                                    op: Op::Get,
                                     key,
                                     value: "".to_string(),
                                 },

--- a/courses/dss/raft/src/lib.rs
+++ b/courses/dss/raft/src/lib.rs
@@ -1,5 +1,3 @@
-#![deny(clippy::all)]
-
 #[allow(unused_imports)]
 #[macro_use]
 extern crate log;

--- a/courses/dss/raft/src/raft/config.rs
+++ b/courses/dss/raft/src/raft/config.rs
@@ -237,14 +237,12 @@ impl Config {
             }
             if let Some(start_term) = start_term {
                 let rafts = self.rafts.lock().unwrap();
-                for r in rafts.iter() {
-                    if let Some(rf) = r {
-                        let term = rf.term();
-                        if term > start_term {
-                            // someone has moved on
-                            // can no longer guarantee that we'll "win"
-                            return None;
-                        }
+                for r in rafts.iter().flatten() {
+                    let term = r.term();
+                    if term > start_term {
+                        // someone has moved on
+                        // can no longer guarantee that we'll "win"
+                        return None;
                     }
                 }
             }
@@ -488,10 +486,8 @@ impl Config {
 impl Drop for Config {
     fn drop(&mut self) {
         if let Ok(rafts) = self.rafts.try_lock() {
-            for r in rafts.iter() {
-                if let Some(rf) = r {
-                    rf.kill();
-                }
+            for r in rafts.iter().flatten() {
+                r.kill();
             }
         }
 

--- a/courses/dss/raft/src/raft/mod.rs
+++ b/courses/dss/raft/src/raft/mod.rs
@@ -98,7 +98,6 @@ impl Raft {
     fn restore(&mut self, data: &[u8]) {
         if data.is_empty() {
             // bootstrap without any state?
-            return;
         }
         // Your code here (2C).
         // Example:

--- a/courses/dss/raft/src/raft/tests.rs
+++ b/courses/dss/raft/src/raft/tests.rs
@@ -258,7 +258,7 @@ fn test_concurrent_starts_2b() {
         }
 
         let mut cmds = vec![];
-        for index in idxes.into_iter().filter_map(|i| i) {
+        for index in idxes.into_iter().flatten() {
             if let Some(cmd) = cfg.wait(index, servers, Some(term)) {
                 cmds.push(cmd.x);
             } else {
@@ -689,11 +689,9 @@ fn test_figure_8_2c() {
         let mut leader = None;
         for i in 0..servers {
             let mut rafts = cfg.rafts.lock().unwrap();
-            if let Some(raft) = rafts.get_mut(i) {
-                if let Some(raft) = raft {
-                    if raft.start(&random_entry(&mut random)).is_ok() {
-                        leader = Some(i);
-                    }
+            if let Some(Some(raft)) = rafts.get_mut(i) {
+                if raft.start(&random_entry(&mut random)).is_ok() {
+                    leader = Some(i);
                 }
             }
         }
@@ -922,7 +920,7 @@ fn internal_churn(unreliable: bool) {
         } else {
             tx.send(None).unwrap();
         }
-    };
+    }
 
     let ncli = 3;
     let mut nrec = vec![];


### PR DESCRIPTION

<!-- Thank you for contributing to talent-plan!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

- this pr updates course/dss/ code to make clippy lint check passed
- Breif description of the problem:
For the raft lab, when compiling with rustc 1.52.1, clippy issues the error: unnecessary nested match, upper_case_acronyms. duplicate lint setting in lib.rs. 

### What is changed and how it works?
 below files changed
``` 
  courses/dss/linearizability/src/models.rs
  courses/dss/raft/src/kvraft/config.rs
  courses/dss/raft/src/kvraft/tests.rs
  courses/dss/raft/src/lib.rs
  courses/dss/raft/src/raft/config.rs
  courses/dss/raft/src/raft/mod.rs
  courses/dss/raft/src/raft/tests.rs
```
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
The test of raft lab is applied
```make test_others```

Side effects
No

Related changes

 - Need to update the documentation
