### PR TITLE
dss: add Raft Lab 2D code

### DIFF
--- a/courses/dss/Makefile
+++ b/courses/dss/Makefile
@@ -18,6 +18,8 @@ test_2b: cargo_test_2b
 
 test_2c: cargo_test_2c
 
+test_2d: cargo_test_2d
+
 test_3: test_3a test_3b
 
 test_3a: cargo_test_3a

--- a/courses/dss/Makefile
+++ b/courses/dss/Makefile
@@ -10,7 +10,7 @@ check:
 
 test: test_others test_2 test_3
 
-test_2: test_2a test_2b test_2c
+test_2: test_2a test_2b test_2c test_2d
 
 test_2a: cargo_test_2a
 

--- a/courses/dss/raft/src/raft/config.rs
+++ b/courses/dss/raft/src/raft/config.rs
@@ -13,9 +13,10 @@ use crate::proto::raftpb::*;
 use crate::raft;
 use crate::raft::persister::*;
 
-static ID: AtomicUsize = AtomicUsize::new(0);
+pub const SNAPSHOT_INTERVAL: u64 = 10;
 
 fn uniqstring() -> String {
+    static ID: AtomicUsize = AtomicUsize::new(0);
     format!("{}", ID.fetch_add(1, Ordering::Relaxed))
 }
 
@@ -88,7 +89,11 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn new(n: usize, unreliable: bool) -> Config {
+    pub fn new(n: usize) -> Config {
+        Config::new_with(n, false, false)
+    }
+
+    pub fn new_with(n: usize, unreliable: bool, snapshot: bool) -> Config {
         init_logger();
 
         let net = labrpc::Network::new();
@@ -121,7 +126,7 @@ impl Config {
         };
 
         for i in 0..n {
-            cfg.start1(i);
+            cfg.start1_ext(i, snapshot);
         }
 
         for i in 0..n {
@@ -137,6 +142,15 @@ impl Config {
 
     fn rpc_total(&self) -> usize {
         self.net.total_count()
+    }
+
+    /// Maximum log size across all servers
+    pub fn log_size(&self) -> usize {
+        self.saved
+            .iter()
+            .map(|s| s.raft_state().len())
+            .max()
+            .unwrap()
     }
 
     // check that there's exactly one leader.
@@ -357,6 +371,14 @@ impl Config {
     /// state persister, to isolate previous instance of
     /// this server. since we cannot really kill it.
     pub fn start1(&mut self, i: usize) {
+        self.start1_ext(i, false);
+    }
+
+    pub fn start1_snapshot(&mut self, i: usize) {
+        self.start1_ext(i, true);
+    }
+
+    fn start1_ext(&mut self, i: usize, snapshot: bool) {
         self.crash1(i);
 
         // a fresh set of outgoing ClientEnd names.
@@ -378,12 +400,11 @@ impl Config {
         // listen to messages from Raft indicating newly committed messages.
         let (tx, apply_ch) = unbounded();
         let storage = self.storage.clone();
+        let rafts = self.rafts.clone();
         let apply = apply_ch.for_each(move |cmd: raft::ApplyMsg| match cmd {
             raft::ApplyMsg::Command { data, index } => {
-                let entry = match labcodec::decode(&data) {
-                    Ok(entry) => entry,
-                    Err(e) => panic!("committed command is not an entry {:?}", e),
-                };
+                // debug!("apply {}", index);
+                let entry = labcodec::decode(&data).expect("committed command is not an entry");
                 let mut s = storage.lock().unwrap();
                 for (j, log) in s.logs.iter().enumerate() {
                     if let Some(old) = log.get(&index) {
@@ -403,6 +424,27 @@ impl Config {
                 log.insert(index, entry);
                 if index > s.max_index {
                     s.max_index = index;
+                }
+                if snapshot && (index + 1) % SNAPSHOT_INTERVAL == 0 {
+                    rafts.lock().unwrap()[i]
+                        .as_ref()
+                        .unwrap()
+                        .snapshot(index, &data);
+                }
+                future::ready(())
+            }
+            raft::ApplyMsg::Snapshot { data, index, term } if snapshot => {
+                // debug!("install snapshot {}", index);
+                if rafts.lock().unwrap()[i]
+                    .as_ref()
+                    .unwrap()
+                    .cond_install_snapshot(term, index, &data)
+                {
+                    let mut s = storage.lock().unwrap();
+                    let log = &mut s.logs[i];
+                    log.clear();
+                    let entry = labcodec::decode(&data).unwrap();
+                    log.insert(index, entry);
                 }
                 future::ready(())
             }
@@ -431,8 +473,10 @@ impl Config {
         // continues to update the Persister.
         // but copy old persister's content so that we always
         // pass Make() the last persisted state.
+        let raft_state = self.saved[i].raft_state();
+        let snapshot = self.saved[i].snapshot();
         let p = SimplePersister::new();
-        p.save_raft_state(self.saved[i].raft_state());
+        p.save_state_and_snapshot(raft_state, snapshot);
         self.saved[i] = Arc::new(p);
 
         if let Some(rf) = self.rafts.lock().unwrap()[i].take() {

--- a/courses/dss/raft/src/raft/mod.rs
+++ b/courses/dss/raft/src/raft/mod.rs
@@ -14,10 +14,20 @@ use self::errors::*;
 use self::persister::*;
 use crate::proto::raftpb::*;
 
-pub struct ApplyMsg {
-    pub command_valid: bool,
-    pub command: Vec<u8>,
-    pub command_index: u64,
+/// As each Raft peer becomes aware that successive log entries are committed,
+/// the peer should send an `ApplyMsg` to the service (or tester) on the same
+/// server, via the `apply_ch` passed to `Raft::new`.
+pub enum ApplyMsg {
+    Command {
+        data: Vec<u8>,
+        index: u64,
+    },
+    // For 2D:
+    Snapshot {
+        data: Vec<u8>,
+        term: u64,
+        index: u64,
+    },
 }
 
 /// State of a raft peer.

--- a/courses/dss/raft/src/raft/mod.rs
+++ b/courses/dss/raft/src/raft/mod.rs
@@ -178,6 +178,21 @@ impl Raft {
             Err(Error::NotLeader)
         }
     }
+
+    fn cond_install_snapshot(
+        &mut self,
+        last_included_term: u64,
+        last_included_index: u64,
+        snapshot: &[u8],
+    ) -> bool {
+        // Your code here (2D).
+        crate::your_code_here((last_included_term, last_included_index, snapshot));
+    }
+
+    fn snapshot(&mut self, index: u64, snapshot: &[u8]) {
+        // Your code here (2D).
+        crate::your_code_here((index, snapshot));
+    }
 }
 
 impl Raft {
@@ -185,6 +200,8 @@ impl Raft {
     #[doc(hidden)]
     pub fn __suppress_deadcode(&mut self) {
         let _ = self.start(&0);
+        let _ = self.cond_install_snapshot(0, 0, &[]);
+        let _ = self.snapshot(0, &[]);
         let _ = self.send_request_vote(0, Default::default());
         self.persist();
         let _ = &self.state;
@@ -276,6 +293,33 @@ impl Node {
     /// threads you generated with this Raft Node.
     pub fn kill(&self) {
         // Your code here, if desired.
+    }
+
+    /// A service wants to switch to snapshot.  
+    ///
+    /// Only do so if Raft hasn't have more recent info since it communicate
+    /// the snapshot on `apply_ch`.
+    pub fn cond_install_snapshot(
+        &self,
+        last_included_term: u64,
+        last_included_index: u64,
+        snapshot: &[u8],
+    ) -> bool {
+        // Your code here.
+        // Example:
+        // self.raft.cond_install_snapshot(last_included_term, last_included_index, snapshot)
+        crate::your_code_here((last_included_term, last_included_index, snapshot));
+    }
+
+    /// The service says it has created a snapshot that has all info up to and
+    /// including index. This means the service no longer needs the log through
+    /// (and including) that index. Raft should now trim its log as much as
+    /// possible.
+    pub fn snapshot(&self, index: u64, snapshot: &[u8]) {
+        // Your code here.
+        // Example:
+        // self.raft.snapshot(index, snapshot)
+        crate::your_code_here((index, snapshot));
     }
 }
 

--- a/courses/dss/raft/src/raft/tests.rs
+++ b/courses/dss/raft/src/raft/tests.rs
@@ -87,6 +87,40 @@ fn test_reelection_2a() {
 }
 
 #[test]
+fn test_many_election_2a() {
+    let servers = 7;
+    let iters = 10;
+    let mut cfg = Config::new(servers);
+
+    cfg.begin("Test (2A): multiple elections");
+
+    cfg.check_one_leader();
+
+    let mut random = rand::thread_rng();
+    for _ in 0..iters {
+        // disconnect three nodes
+        let i1 = random.gen::<usize>() % servers;
+        let i2 = random.gen::<usize>() % servers;
+        let i3 = random.gen::<usize>() % servers;
+        cfg.disconnect(i1);
+        cfg.disconnect(i2);
+        cfg.disconnect(i3);
+
+        // either the current leader should still be alive,
+        // or the remaining four should elect a new one.
+        cfg.check_one_leader();
+
+        cfg.connect(i1);
+        cfg.connect(i2);
+        cfg.connect(i3);
+    }
+
+    cfg.check_one_leader();
+
+    cfg.end();
+}
+
+#[test]
 fn test_basic_agree_2b() {
     let servers = 5;
     let mut cfg = Config::new(servers);

--- a/courses/dss/raft/src/raft/tests.rs
+++ b/courses/dss/raft/src/raft/tests.rs
@@ -11,7 +11,7 @@ use futures::executor::block_on;
 use futures::future;
 use rand::{rngs::ThreadRng, Rng};
 
-use crate::raft::config::{Config, Entry, Storage};
+use crate::raft::config::{Config, Entry, Storage, SNAPSHOT_INTERVAL};
 use crate::raft::Node;
 
 /// The tester generously allows solutions to complete elections in one second
@@ -27,7 +27,7 @@ fn random_entry(rnd: &mut ThreadRng) -> Entry {
 #[test]
 fn test_initial_election_2a() {
     let servers = 3;
-    let mut cfg = Config::new(servers, false);
+    let mut cfg = Config::new(servers);
 
     cfg.begin("Test (2A): initial election");
 
@@ -55,7 +55,7 @@ fn test_initial_election_2a() {
 #[test]
 fn test_reelection_2a() {
     let servers = 3;
-    let mut cfg = Config::new(servers, false);
+    let mut cfg = Config::new(servers);
     cfg.begin("Test (2A): election after network failure");
 
     let leader1 = cfg.check_one_leader();
@@ -89,7 +89,7 @@ fn test_reelection_2a() {
 #[test]
 fn test_basic_agree_2b() {
     let servers = 5;
-    let mut cfg = Config::new(servers, false);
+    let mut cfg = Config::new(servers);
     cfg.begin("Test (2B): basic agreement");
 
     let iters = 3;
@@ -111,7 +111,7 @@ fn test_basic_agree_2b() {
 #[test]
 fn test_fail_agree_2b() {
     let servers = 3;
-    let mut cfg = Config::new(servers, false);
+    let mut cfg = Config::new(servers);
 
     cfg.begin("Test (2B): agreement despite follower disconnection");
 
@@ -142,7 +142,7 @@ fn test_fail_agree_2b() {
 #[test]
 fn test_fail_no_agree_2b() {
     let servers = 5;
-    let mut cfg = Config::new(servers, false);
+    let mut cfg = Config::new(servers);
 
     cfg.begin("Test (2B): no agreement if too many followers disconnect");
 
@@ -194,7 +194,7 @@ fn test_fail_no_agree_2b() {
 #[test]
 fn test_concurrent_starts_2b() {
     let servers = 3;
-    let mut cfg = Config::new(servers, false);
+    let mut cfg = Config::new(servers);
 
     cfg.begin("Test (2B): concurrent start()s");
     let mut success = false;
@@ -292,7 +292,7 @@ fn test_concurrent_starts_2b() {
 #[test]
 fn test_rejoin_2b() {
     let servers = 3;
-    let mut cfg = Config::new(servers, false);
+    let mut cfg = Config::new(servers);
 
     cfg.begin("Test (2B): rejoin of partitioned leader");
 
@@ -339,7 +339,7 @@ fn test_rejoin_2b() {
 #[test]
 fn test_backup_2b() {
     let servers = 5;
-    let mut cfg = Config::new(servers, false);
+    let mut cfg = Config::new(servers);
 
     cfg.begin("Test (2B): leader backs up quickly over incorrect follower logs");
 
@@ -426,7 +426,7 @@ fn test_count_2b() {
         n
     }
 
-    let mut cfg = Config::new(SERVERS, false);
+    let mut cfg = Config::new(SERVERS);
 
     cfg.begin("Test (2B): RPC counts aren't too high");
 
@@ -547,7 +547,7 @@ fn test_count_2b() {
 #[test]
 fn test_persist1_2c() {
     let servers = 3;
-    let mut cfg = Config::new(servers, false);
+    let mut cfg = Config::new(servers);
 
     cfg.begin("Test (2C): basic persistence");
 
@@ -593,7 +593,7 @@ fn test_persist1_2c() {
 #[test]
 fn test_persist2_2c() {
     let servers = 5;
-    let mut cfg = Config::new(servers, false);
+    let mut cfg = Config::new(servers);
 
     cfg.begin("Test (2C): more persistence");
 
@@ -639,7 +639,7 @@ fn test_persist2_2c() {
 #[test]
 fn test_persist3_2c() {
     let servers = 3;
-    let mut cfg = Config::new(servers, false);
+    let mut cfg = Config::new(servers);
 
     cfg.begin("Test (2C): partitioned leader and one follower crash, leader restarts");
 
@@ -677,7 +677,7 @@ fn test_persist3_2c() {
 #[test]
 fn test_figure_8_2c() {
     let servers = 5;
-    let mut cfg = Config::new(servers, false);
+    let mut cfg = Config::new(servers);
 
     cfg.begin("Test (2C): Figure 8");
 
@@ -738,7 +738,7 @@ fn test_unreliable_agree_2c() {
     let servers = 5;
 
     let cfg = {
-        let mut cfg = Config::new(servers, true);
+        let mut cfg = Config::new_with(servers, true, false);
         cfg.begin("Test (2C): unreliable agreement");
         Arc::new(cfg)
     };
@@ -780,7 +780,7 @@ fn test_unreliable_agree_2c() {
 #[test]
 fn test_figure_8_unreliable_2c() {
     let servers = 5;
-    let mut cfg = Config::new(servers, true);
+    let mut cfg = Config::new_with(servers, true, false);
 
     cfg.begin("Test (2C): Figure 8 (unreliable)");
     let mut random = rand::thread_rng();
@@ -855,7 +855,7 @@ fn test_figure_8_unreliable_2c() {
 
 fn internal_churn(unreliable: bool) {
     let servers = 5;
-    let mut cfg = Config::new(servers, unreliable);
+    let mut cfg = Config::new_with(servers, unreliable, false);
     if unreliable {
         cfg.begin("Test (2C): unreliable churn")
     } else {
@@ -922,7 +922,7 @@ fn internal_churn(unreliable: bool) {
         } else {
             tx.send(None).unwrap();
         }
-    };
+    }
 
     let ncli = 3;
     let mut nrec = vec![];
@@ -1013,4 +1013,102 @@ fn test_reliable_churn_2c() {
 #[test]
 fn test_unreliable_churn_2c() {
     internal_churn(true);
+}
+
+fn snap_common(name: &str, disconnect: bool, reliable: bool, crash: bool) {
+    const MAX_LOG_SIZE: usize = 2000;
+
+    let iters = 30;
+    let servers = 3;
+    let mut cfg = Config::new_with(servers, !reliable, true);
+
+    cfg.begin(name);
+
+    let mut random = rand::thread_rng();
+    cfg.one(random_entry(&mut random), servers, true);
+    let mut leader1 = cfg.check_one_leader();
+
+    for i in 0..iters {
+        let mut victim = (leader1 + 1) % servers;
+        let mut sender = leader1;
+        if i % 3 == 1 {
+            sender = (leader1 + 1) % servers;
+            victim = leader1;
+        }
+
+        if disconnect {
+            cfg.disconnect(victim);
+            cfg.one(random_entry(&mut random), servers - 1, true);
+        }
+        if crash {
+            cfg.crash1(victim);
+            cfg.one(random_entry(&mut random), servers - 1, true);
+        }
+        // send enough to get a snapshot
+        for _ in 0..=SNAPSHOT_INTERVAL {
+            let _ = cfg.rafts.lock().unwrap()[sender]
+                .as_ref()
+                .unwrap()
+                .start(&random_entry(&mut random));
+        }
+        // let applier threads catch up with the Start()'s
+        cfg.one(random_entry(&mut random), servers - 1, true);
+
+        assert!(cfg.log_size() < MAX_LOG_SIZE, "log size too large");
+
+        if disconnect {
+            // reconnect a follower, who maybe behind and
+            // needs to receive a snapshot to catch up.
+            cfg.connect(victim);
+            cfg.one(random_entry(&mut random), servers, true);
+            leader1 = cfg.check_one_leader();
+        }
+        if crash {
+            cfg.start1_snapshot(victim);
+            cfg.connect(victim);
+            cfg.one(random_entry(&mut random), servers, true);
+            leader1 = cfg.check_one_leader();
+        }
+    }
+    cfg.end();
+}
+
+#[test]
+fn test_snapshot_basic_2d() {
+    snap_common("Test (2D): snapshots basic", false, true, false);
+}
+
+#[test]
+fn test_snapshot_install_2d() {
+    snap_common(
+        "Test (2D): install snapshots (disconnect)",
+        true,
+        true,
+        false,
+    );
+}
+
+#[test]
+fn test_snapshot_install_unreliable_2d() {
+    snap_common(
+        "Test (2D): install snapshots (disconnect+unreliable)",
+        true,
+        false,
+        false,
+    );
+}
+
+#[test]
+fn test_snapshot_install_crash_2d() {
+    snap_common("Test (2D): install snapshots (crash)", false, true, true);
+}
+
+#[test]
+fn test_snapshot_install_unreliable_crash_2d() {
+    snap_common(
+        "Test (2D): install snapshots (unreliable+crash)",
+        false,
+        false,
+        true,
+    );
 }


### PR DESCRIPTION
<!-- Thank you for contributing to talent-plan!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

- Breif description of the problem:
  Add lab 2D code from MIT 6.824 (Spring 2021).

### What is changed and how it works?

- Add 1 test for lab 2A.
- Add 5 tests for lab 2D.
- Add 2 interfaces between service and Raft: `snapshot` and `cond_install_snapshot`.
- Update `Config` for handling snapshot apply messages.

Here is my solution with these changes that can pass lab 2D:
https://github.com/wangrunji0408/talent-plan/tree/0362b3abcd6731649284b32b408a743273a1b63f

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Side effects

 - None

Related changes

 - Need to update the documentation
