### PR TITLE
courses/rust/projects/project-4/README.md Updates signature of Threadpool::new

### DIFF
--- a/courses/rust/projects/project-4/README.md
+++ b/courses/rust/projects/project-4/README.md
@@ -76,7 +76,7 @@ it will become obvious by the end of this project.
 The second is that the library in this project contains a new _trait_,
 `ThreadPool`. It contains the following methods:
 
-- `ThreadPool::new(threads: u32) -> Result<ThreadPool>`
+- `ThreadPool::new(threads: u32) -> Result<Self> where Self: Sized`
 
   Creates a new thread pool, immediately spawning the specified number of
   threads.


### PR DESCRIPTION
This update is needed, because the current signature is rejected by the compile with the message:

```
the size for values of type `(dyn ThreadPool + 'static)` cannot be known at compilation time
the trait `Sized` is not implemented for `(dyn ThreadPool + 'static)`rustcE0277
result.rs(503, 17): required by a bound in `std::result::Result`
```

### What is changed and how it works?
I changed the return value from `Result<ThreadPool>` to `Result<Self> where Self: Sized`, which matches the trait definition in `courses/rust/projects/project-4/src/thread_pool/mod.rs`

### Check List <!--REMOVE the items that are not applicable-->
