### PR TITLE
courses/rust/projects/project-4: fix inconsistencies in description and code

### DIFF
--- a/courses/rust/projects/project-4/README.md
+++ b/courses/rust/projects/project-4/README.md
@@ -998,7 +998,7 @@ never changes &mdash; it is immutable, and immutable types are `Sync` in Rust,
 so it doesn't even need any protection at all. Every thread can read it at once
 through a shared reference.
 
-`readers: HashMap<u64, BufReaderWithPos<File>>` is the read handle to the
+`reader: BufReaderWithPos<File>` is the read handle to the
 current log file. It needs to change to a new log file after compaction.
 
 `writer: BufWriterWithPos<File>` is the write handle to the current log file.


### PR DESCRIPTION
<!-- Thank you for contributing to talent-plan!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

- Breif description of the problem:
In the [example](https://github.com/pingcap/talent-plan/blob/master/courses/rust/projects/project-4/README.md#explaining-our-example-data-structure), field `reader` is of type `BufReaderWithPos<File>`, but the type of this field in the following description is `HashMap<u64, BufReaderWithPos<File>>`.

### What is changed and how it works?

Update the type in the description to `BufReaderWithPos<File>`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

