### PR TITLE
courses/rust/projects/project-1: Add note about clap 3.x

### DIFF
--- a/courses/rust/projects/project-1/README.md
+++ b/courses/rust/projects/project-1/README.md
@@ -1,5 +1,7 @@
 # PNA Rust Project 1: The Rust toolbox
 
+> Note: The following guide is based on `clap 2.x`, and now `clap 3.x` is released. You can read the changelog of clap to find the difference between 2.x and 3.x, and after knowing the difference, you can choose to skip some of the steps in this guide.
+
 **Task**: Create an in-memory key/value store that passes simple tests and responds
 to command-line arguments.
 


### PR DESCRIPTION
<!-- Thank you for contributing to talent-plan!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

- Issue number: close #332  <!-- remove this line if no issue to close -->
- As of clap 3.x has ben released, we need to update the guide.

### What is changed and how it works?

 - We add a note at the top of the guide, letting the readers to find out the difference between clap 2.x and 3.x by themselves. By this way, we can make the reader to do more exercise on reading docs and make them get used to the quickly changing rust ecosystem.   
 - The readers can decide to still use the 2.x or upgrade to the 3.x by themselves, both way is ok.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - No code
