### PR TITLE
courses/tp102: Update outdated links for github learning material

### DIFF
--- a/courses/tp102-how-to-use-git-github.md
+++ b/courses/tp102-how-to-use-git-github.md
@@ -31,7 +31,7 @@ None. This course is a great introduction for your first day on GitHub.
 
 **Learning Material(s):**
 
-* [Introduction to GitHub](https://lab.github.com/githubtraining/introduction-to-github), an open source course created by [The GitHub Training Team](https://lab.github.com/githubtraining)
+* [Introduction to GitHub](https://github.com/skills/introduction-to-github), an open source course created by [GitHub Skills](https://github.com/skills)
  
 **Suggested Assignments:**
 
@@ -41,7 +41,7 @@ None. This course is a great introduction for your first day on GitHub.
 
 **Learning Material(s):**
 
-* [Reviewing pull requests](https://lab.github.com/githubtraining/reviewing-pull-requests), an open source course created by [The GitHub Training Team](https://lab.github.com/githubtraining)
+* [Reviewing pull requests](https://github.com/skills/review-pull-requests), an open source course created by [GitHub Skills](https://github.com/skills)
  
 **Suggested Assignments:**
 
@@ -51,7 +51,7 @@ None. This course is a great introduction for your first day on GitHub.
 
 **Learning Material(s):**
 
-* [Managing merge conflicts](https://lab.github.com/githubtraining/managing-merge-conflicts), an open source course created by [The GitHub Training Team](https://lab.github.com/githubtraining)
+* [Managing merge conflicts](https://github.com/skills/resolve-merge-conflicts), an open source course created by [GitHub Skills](https://github.com/skills)
  
 **Suggested Assignments:**
 
@@ -61,7 +61,7 @@ None. This course is a great introduction for your first day on GitHub.
 
 **Learning Material(s):**
 
-* [Communicating using Markdown](https://lab.github.com/githubtraining/communicating-using-markdown), an open source course created by [The GitHub Training Team](https://lab.github.com/githubtraining)
+* [Communicating using Markdown](https://github.com/skills/communicate-using-markdown), an open source course created by [GitHub Skills](https://github.com/skills)
  
 **Suggested Assignments:**
 
@@ -85,5 +85,5 @@ No assignments, the git skill will be tested all the time you participate in an 
 
 Special Thanks to:
 
-* `Producer Wen`, `Qinyao Yang`, and `Jason Zhang`for testing this course and updating the materials.
-* [The GitHub Training Team](https://lab.github.com/githubtraining) for creating open source courses above.
+* `Producer Wen`, `Qinyao Yang`, and `Jason Zhang` for testing this course and updating the materials.
+* [GitHub Skills](https://github.com/skills) for creating open source courses above.


### PR DESCRIPTION
### What problem does this PR solve?
- Brief description of the problem:
Current links for first 4 chapter's learning materials are invalid; 404 error. 

### What is changed and how it works?
Update links to the new url of the repositories under GitHub Skills

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - No code
