### PR TITLE
rust project-3 tests/cli.rs: revise mistyped "get", 

### DIFF
--- a/courses/rust/projects/project-3/tests/cli.rs
+++ b/courses/rust/projects/project-3/tests/cli.rs
@@ -80,7 +80,7 @@ fn client_cli_invalid_set() {
 
     Command::cargo_bin("kvs-client")
         .unwrap()
-        .args(&["get", "key", "--unknown-flag"])
+        .args(&["set", "key", "--unknown-flag"])
         .current_dir(&temp_dir)
         .assert()
         .failure();


### PR DESCRIPTION
<!-- Thank you for contributing to talent-plan!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

In rust project-3 tests/cli.rs `cli_invalid_set` function, the fifth command should test "set" command, while testing "get".

### What is changed and how it works?

Replace "get" with "set".

### Tests
I suppose this PR do not need further tests.