### PR TITLE
courses/dss: fix clippy warning when running 'make test_others'

### DIFF
--- a/courses/dss/labrpc/src/lib.rs
+++ b/courses/dss/labrpc/src/lib.rs
@@ -417,7 +417,7 @@ pub mod tests {
             pool.spawn_ok(async move {
                 let x = i + 100;
                 // this call ought to return false.
-                let _ = cli.handler2(&JunkArgs { x });
+                let _ = cli.handler2(&JunkArgs { x }).await;
                 sender.send(true).unwrap();
             });
         }

--- a/courses/dss/raft/src/kvraft/config.rs
+++ b/courses/dss/raft/src/kvraft/config.rs
@@ -169,7 +169,7 @@ impl Config {
     pub fn connect_all(&self) {
         let servers = self.servers.lock().unwrap();
         for i in 0..self.n {
-            self.connect(i, &self.all(), &*servers);
+            self.connect(i, &self.all(), &servers);
         }
     }
 
@@ -178,12 +178,12 @@ impl Config {
         debug!("partition servers into: {:?} {:?}", p1, p2);
         let servers = self.servers.lock().unwrap();
         for i in p1 {
-            self.disconnect(*i, p2, &*servers);
-            self.connect(*i, p1, &*servers);
+            self.disconnect(*i, p2, &servers);
+            self.connect(*i, p1, &servers);
         }
         for i in p2 {
-            self.disconnect(*i, p1, &*servers);
-            self.connect(*i, p2, &*servers);
+            self.disconnect(*i, p1, &servers);
+            self.connect(*i, p2, &servers);
         }
     }
 
@@ -232,7 +232,7 @@ impl Config {
     /// Shutdown a server by isolating it
     pub fn shutdown_server(&self, i: usize) {
         let mut servers = self.servers.lock().unwrap();
-        self.disconnect(i, &self.all(), &*servers);
+        self.disconnect(i, &self.all(), &servers);
 
         // disable client connections to the server.
         // it's important to do this before creating

--- a/courses/dss/raft/src/raft/tests.rs
+++ b/courses/dss/raft/src/raft/tests.rs
@@ -846,7 +846,7 @@ fn test_figure_8_unreliable_2c() {
 
         if (random.gen::<usize>() % 1000) < 100 {
             let ms = random.gen::<u64>() % (RAFT_ELECTION_TIMEOUT.as_millis() as u64 / 2);
-            thread::sleep(Duration::from_millis(ms as u64));
+            thread::sleep(Duration::from_millis(ms));
         } else {
             let ms = random.gen::<u64>() % 13;
             thread::sleep(Duration::from_millis(ms));


### PR DESCRIPTION
<!-- Thank you for contributing to talent-plan!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Running `make test_others`, as recommended at the beginning of [The Raft Lab](https://github.com/pingcap/talent-plan/blob/master/courses/dss/raft/README.md#the-raft-lab) currently fails, as it indirectly calls `cargo clippy`, with `-Dwarnings` and there are some lints that fail.

This PR fixes them.